### PR TITLE
fix:壁衝突のメッセージが大量に出るバグを修正(#94)

### DIFF
--- a/inc/cub3d.h
+++ b/inc/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: yshimazu <yshimazu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/02/24 12:00:27 by user42            #+#    #+#             */
-/*   Updated: 2022/03/12 10:41:16 by user42           ###   ########.fr       */
+/*   Updated: 2022/03/13 11:27:44 by user42           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -69,6 +69,7 @@ typedef struct s_minimap {
 // 変数をいくつか定数にするかも
 typedef struct s_player {
 	t_point	pos;
+	t_point	wall_hit;
 	double	radius;
 	double	walk_direction;
 	bool	should_move;

--- a/src/game/update.c
+++ b/src/game/update.c
@@ -6,21 +6,24 @@
 /*   By: yshimazu <yshimazu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/01 11:36:52 by user42            #+#    #+#             */
-/*   Updated: 2022/03/12 10:44:25 by user42           ###   ########.fr       */
+/*   Updated: 2022/03/13 11:48:38 by user42           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "constants.h"
 #include "cub3d.h"
 
+static bool	point_equals(t_point *p1, t_point *p2)
+{
+	return (p1->x == p2->x && p1->y == p2->y);
+}
+
 static void	move_player(t_player *player, t_map *map, t_minimap *mini)
 {
-	double		move_angle;
-	t_point		next;
-	t_point		check;
+	double	move_angle;
+	t_point	next;
+	t_point	check;
 
-	if (!player->should_move)
-		return ;
 	move_angle = normalize_angle(player->angle + player->walk_direction);
 	next.x = player->pos.x + cos(move_angle) * MOVE_STEP;
 	next.y = player->pos.y + sin(move_angle) * MOVE_STEP;
@@ -37,12 +40,17 @@ static void	move_player(t_player *player, t_map *map, t_minimap *mini)
 	}
 	else
 	{
-		ft_putendl_fd(MSG_WALL_COLLISION, STDERR_FILENO);
+		if (!point_equals(&check, &player->wall_hit))
+			ft_putendl_fd(MSG_WALL_COLLISION, STDERR_FILENO);
+		player->wall_hit = check;
 	}
 }
 
 void	update(t_game *game)
 {
-	move_player(&game->player, &game->map, &game->mini);
+	if (game->player.should_move)
+	{
+		move_player(&game->player, &game->map, &game->mini);
+	}
 	cast_all_rays(game->ray, &game->player, &game->map);
 }

--- a/src/init/init_player.c
+++ b/src/init/init_player.c
@@ -6,7 +6,7 @@
 /*   By: yshimazu <yshimazu@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/03/07 21:31:47 by yshimazu          #+#    #+#             */
-/*   Updated: 2022/03/12 10:40:53 by user42           ###   ########.fr       */
+/*   Updated: 2022/03/13 11:29:03 by user42           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,6 +40,7 @@ static void	set_pos_angle(t_player *player, char **map_ptr)
 			{
 				player->pos.y = y * TILE_SIZE + TILE_SIZE / 2;
 				player->pos.x = x * TILE_SIZE + TILE_SIZE / 2;
+				player->wall_hit = player->pos;
 				set_angle(player, map_ptr[y][x]);
 			}
 			x++;


### PR DESCRIPTION
## Issue
 #94 
## 概要
壁衝突後に移動キーを押し続けてもメッセージがでないようにしました。
## コメント
条件や設定を変えてません。対症療法です。
これ以外だとキーの連続入力を制御する必要がありそうなので、ちょっと面倒そうです。
